### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ COPY package*.json ./
 RUN npm ci --production
 
 COPY --from=builder /app/build ./build
+COPY --from=builder /app/demo ./demo
 
-EXPOSE 8080
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -71,10 +71,24 @@ Well, I love the idea of building things in public. Also, I know that I can some
 
 The `0.0.1-alpha` is truly alpha, and there is still a lot of work to be done! The following list contains a high-level plan for the next steps (to actually release `0.0.1`):
 
-- [ ] Docker image (right now, the Docker image is not working properly)
+- [x] Docker image (right now, the Docker image is not working properly)
 - [ ] CLI (a CLI tool would create a demo-like folder with a built-in Docker file that you could run)
 - [ ] Slack messaging
 - [ ] Validation (there is missing validation for almost all inputs)
 - [ ] Ensure that Emitbase performs only `SELECT` queries.
 - [ ] Tests for core functionalities
 - [ ] Documentation
+
+## Run Emitbase in Docker
+
+1. Build docker image:
+
+```bash
+$ docker build -t emitbase-v0.0.1-alpha
+```
+
+2. Run it:
+
+```bash
+$ docker run -p 3000:3000 emitbase-v0.0.1-alpha
+```

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,20 +2,23 @@ import { loadProfile, loadDefintions } from './files.js';
 import { registerThreshold } from './engine.js';
 import { getJobs } from './services.js';
 import { Threshold, Notification } from './models.js';
+import path from 'path';
 
 (async function main() {
   /**
    * TODO: Obvious problem is that currently the whole system supports only PostgreSQL connections / quesries. For POC it is sufficient.
    */
-  const connectionDetails = loadProfile('demo/profiles.yml');
+  const connectionDetails = loadProfile(path.join('demo', 'profiles.yml'));
   const connectionDetailsTarget: string = connectionDetails.emitbase.target;
   const selectedDatabaseConnectionDetails = connectionDetails.emitbase.databases[connectionDetailsTarget];
   const selectedNotificationsConnectionDetails = connectionDetails.emitbase.notifications[connectionDetailsTarget].email;
   // TODO: Add TypeGuard
-  const thresholds = loadDefintions('demo/thresholds') as Threshold[];
+  const thresholds = loadDefintions(path.join('demo', 'thresholds')) as Threshold[];
   // TODO: Add TypeGuard
-  const notifications = loadDefintions('demo/notifications') as Notification[];
+  const notifications = loadDefintions(path.join('demo', 'notifications')) as Notification[];
   const jobs = getJobs(thresholds, notifications);
 
   registerThreshold(jobs, selectedDatabaseConnectionDetails, selectedNotificationsConnectionDetails);
+
+  console.log('Emitbase is running! 🚀');
 })();


### PR DESCRIPTION
- Add demo folder to Dockerfile
- Add steps on how to run Emitbase in docker to README.md

The reason Emitbase did not work in Docker was that the `demo` folder was missing in the final build.